### PR TITLE
Fix User32.EnumWindows crash

### DIFF
--- a/lib/TrayBird.cs
+++ b/lib/TrayBird.cs
@@ -312,8 +312,9 @@ namespace ThunderbirdTray
                     return true;
                 }
 
-                var classNameBuilder = new StringBuilder();
-                var classNameLength = User32.GetClassName(hWnd, classNameBuilder, int.MaxValue);
+                // Class names can only be a max length of 256 characters
+                var classNameBuilder = new StringBuilder(256);
+                var classNameLength = User32.GetClassName(hWnd, classNameBuilder, classNameBuilder.Capacity);
                 var className = classNameBuilder.ToString();
 
                 if (className != thunderbirdMainWindowClassName)
@@ -321,8 +322,9 @@ namespace ThunderbirdTray
                     return true;
                 }
 
-                var windowTextBuilder = new StringBuilder();
-                var windowTextLength = User32.GetWindowText(hWnd, windowTextBuilder, int.MaxValue);
+                int length = User32.GetWindowTextLength(hWnd);
+                var windowTextBuilder = new StringBuilder(length + 1);
+                var windowTextLength = User32.GetWindowText(hWnd, windowTextBuilder, windowTextBuilder.Capacity);
                 var windowText = windowTextBuilder.ToString();
 
                 if (!windowText.EndsWith(thunderbirdMainWindowTextEndsWith))

--- a/lib/Win32.cs
+++ b/lib/Win32.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -82,6 +82,9 @@ namespace ThunderbirdTray.Win32
 
         [DllImport("user32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
         public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern int GetWindowTextLength(IntPtr hWnd);
 
         [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Ansi)]
         public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);


### PR DESCRIPTION
See #10 .

A maximum length of `int.MaxValue` for `User32.GetClassName()` or `User32.GetWindowText()` caused a crash.
This PR fixes this by preallocating the StringBuilders and reading smaller strings. 